### PR TITLE
remove default url from config so urls are now relative

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL         = "http://example.net/"
+baseurl         = ""
 languageCode    = "en-us"
 title           = "Willow Bark Co-op"
 theme           = "salix"


### PR DESCRIPTION
This was the cause of the CSS not loading when building despite it not being an issue when using the development server.

There's some suggestion that absolute URLs are better for SEO but we could add it back in when we have a domain, also it's a single page so we don't really have any links to index...