### PR TITLE
Switch base URL to use willowbark.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl         = ""
+baseurl         = "https://willowbark.org"
 languageCode    = "en-us"
 title           = "Willow Bark Co-op"
 theme           = "salix"


### PR DESCRIPTION
We can switch over to the `willowbark.org` domain soon. Once the DNS records are in place this PR can be merged.