### PR TITLE
Fix baseurl on generated previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,9 @@
   [headers.values]
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
+
+[context.deploy-preview]
+command = "hugo -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy]
+command = "hugo -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
When generating previews on Netlify, the baseurl will not be
willowbark.org, meaning that CSS won't load because CORS won't be
correct (and even if it were, we wouldn't be loading our changes that we
want to preview, we'd be loading the production CSS).
Instead, configure netlify to override baseurl on build so that preview
sites can actually load the local CSS and other assets.

Signed-off-by: Sam Whited <sam@samwhited.com>