### PR TITLE
update contact footer to match design

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,4 +18,4 @@ better software for a better world."""
 [params.contact]
 
 org   = "Willow Bark Co-op"
-email = "hello@willowbark.org"
+email = "hello@example.net"

--- a/config.toml
+++ b/config.toml
@@ -18,4 +18,4 @@ better software for a better world."""
 [params.contact]
 
 org   = "Willow Bark Co-op"
-email = "hello@example.net"
+email = "hello@willowbark.org"

--- a/content/_index.md
+++ b/content/_index.md
@@ -88,6 +88,6 @@ operate efficiently and with minimal waste.
 
 {{< /section >}}
 
-{{< section title="Contact" anchor="contact" class="minimal-section" >}}
-We'd love to work with you, why not drop us an email at [hello@willowbark.org](mailto:hello@willowbark.org)
-{{< /section >}}
+{{< contact title="Contact" anchor="contact" >}}
+We'd love to work with you, why not drop us an email at 
+{{< /contact >}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -88,6 +88,16 @@ operate efficiently and with minimal waste.
 
 {{< /section >}}
 
-{{< contact title="Contact" anchor="contact" >}}
-We'd love to work with you, why not drop us an email at 
-{{< /contact >}}
+{{< flexsection title="Contact" anchor="contact" class="contact">}}
+
+<p>We'd love to work with you, why not drop us an email at</p>
+
+{{< email >}}
+
+<img
+	src="img/pigeon.png"
+	alt="a pigeon in flight possibly delivering your message."
+	aria-hidden="true"
+/>
+
+{{< /flexsection >}}

--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -172,6 +172,7 @@ section.minimal-section a {
 .contact a {
 	color: white;
 	font-family: "Source Code Pro", monospace;
+	font-weight: 700;
 	text-decoration: none;
 	margin: 3rem 0 0 0;
 	grid-column: 2 / 3;

--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -74,6 +74,7 @@ header p {
 
 section h2 {
 	font-size: 10rem;
+	margin: 0;
 }
 
 section > div {
@@ -152,13 +153,52 @@ section.minimal-section a {
 	font-weight: bold;
 }
 
+.contact {
+	background-color: var(--color-lime);
+	color: var(--color-blue);
+	font-size: 1.3rem;
+}
+
+.contact div div {
+	display: grid;
+	grid-template-columns: max-content max-content 1fr;
+	grid-template-rows: 1fr;
+}
+
+.contact h2, p {
+	mix-blend-mode: darken;
+}
+
+.contact a {
+	color: white;
+	font-family: "Source Code Pro", monospace;
+	text-decoration: none;
+	margin: 3rem 0 0 0;
+	grid-column: 2 / 3;
+	grid-row: 1 / 2;
+	z-index: 1;
+}
+
+.contact p {
+	padding-right: 0.5rem;
+	margin: 3rem 0 0 0;
+	mix-blend-mode: darken;
+	z-index: 1;
+}
+
+.contact img {
+	width: 50vmin;
+	grid-column: 2 / span 2;
+	grid-row: 1 / 2;
+}
+
 @media (max-width: 945px) {
 	header {
 		padding: 0;
 	}
 
 	section {
-		padding: 1rem;
+		padding: 2rem;
 	}
 
 	header {
@@ -173,6 +213,24 @@ section.minimal-section a {
 	h1 {
 		font-size: 5rem !important;
 	}
+		
+	.contact div div {
+		grid-template-columns: 1fr;
+		grid-template-rows: max-content max-content;
+	}
+
+	.contact a {
+		grid-column: 1 / 2;
+		grid-row: 2 / 3;
+	}
+
+	.contact img {
+		width: 100%;
+		align-self: center;
+		left: 1rem;
+		grid-column: 1 / 2;
+		grid-row: 2 / 3;
+	}
 }
 
 @media (max-width: 750px) {
@@ -181,7 +239,7 @@ section.minimal-section a {
 	}
 
 	h2 {
-		font-size: 3rem !important;
+		font-size: 5rem !important;
 	}
 	
 	section.columns-section > div > div {

--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -170,8 +170,9 @@ section.minimal-section a {
 }
 
 .contact a {
-	color: white;
+	color: var(--color-lime);
 	font-family: "Source Code Pro", monospace;
+	font-weight: 700;
 	text-decoration: none;
 	margin: 3rem 0 0 0;
 	grid-column: 2 / 3;
@@ -181,7 +182,6 @@ section.minimal-section a {
 	width: max-content;
 	height: max-content;
 	padding: 0.5rem 1rem;
-	border-radius: 1rem;
 }
 
 .contact p {

--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -172,19 +172,26 @@ section.minimal-section a {
 .contact a {
 	color: white;
 	font-family: "Source Code Pro", monospace;
-	font-weight: 700;
 	text-decoration: none;
 	margin: 3rem 0 0 0;
 	grid-column: 2 / 3;
 	grid-row: 1 / 2;
 	z-index: 1;
+	background-color: var(--color-navy);
+	width: max-content;
+	height: max-content;
+	padding: 0.5rem 1rem;
+	border-radius: 1rem;
 }
 
 .contact p {
 	padding-right: 0.5rem;
 	margin: 3rem 0 0 0;
+	font-size: 1.5rem;
 	mix-blend-mode: darken;
 	z-index: 1;
+	height: max-content;
+	padding: 0.5rem;
 }
 
 .contact img {

--- a/themes/salix/layouts/shortcodes/contact.html
+++ b/themes/salix/layouts/shortcodes/contact.html
@@ -1,0 +1,18 @@
+<section class="contact">
+	<div>
+		<h2 id="contact">Contact</h2>
+		<div>
+			<p>
+				{{ .Inner }}
+			</p>
+			<a href="mailto:{{ .Site.Params.contact.email }}">
+				{{ .Site.Params.contact.email }}
+			</a>
+			<img
+				src="img/pigeon.png"
+				alt="a pigeon in flight possibly delivering your message."
+				aria-hidden="true"
+			/>
+		</div>
+	</div>
+</section>

--- a/themes/salix/layouts/shortcodes/email.html
+++ b/themes/salix/layouts/shortcodes/email.html
@@ -1,0 +1,3 @@
+<a href="mailto:{{ .Site.Params.contact.email }}">
+	{{ .Site.Params.contact.email }}
+</a>

--- a/themes/salix/layouts/shortcodes/flexsection.html
+++ b/themes/salix/layouts/shortcodes/flexsection.html
@@ -1,5 +1,5 @@
 <section{{ with .Get "class" }} class="{{.}}"{{ end }}>
-	<h2>{{ .Get "title" }}</h2>
+	<h2{{ with .Get "anchor" }} id="{{.}}"{{ end }}>{{ .Get "title" }}</h2>
 	<div><div>
 	{{ .Inner | safeHTML }}
 	</div></div>


### PR DESCRIPTION
The shortcode takes a message as the `.Inner` value and retrieves the email address from config.
It uses grid to accurately overlay the email address and image but does not use BEM.

Sidenote, Sam and Luke have said they prefer bold to black font-weight so I've left that as is for the moment.