### PR TITLE
bug fix - remove nested main tag in template

### DIFF
--- a/themes/salix/layouts/index.html
+++ b/themes/salix/layouts/index.html
@@ -1,5 +1,3 @@
 {{ define "main" }}
-<main role="main">
 	{{ .Content }}
-</main>
 {{ end }}


### PR DESCRIPTION
Just a small fix, the `main` tag appeared  in both the `index` and `baseof` templates.