### PR TITLE
Don't show contact button except on main page

### DIFF
--- a/themes/salix/layouts/_default/baseof.html
+++ b/themes/salix/layouts/_default/baseof.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ if .Language.Lang}}{{ .Language.Lang }}{{ else }}{{ .Site.LanguageCode }}{{ end }}">
-    {{- partial "head.html" . -}}
-    <body>
-        {{- partial "header.html" . -}}
-        <main role="main">
-        {{- block "main" . }}{{- end }}
-        </main>
-        {{- partial "footer.html" . -}}
-    </body>
+  {{- partial "head.html" . -}}
+  <body>
+    {{- block "contact" . }}{{- end }}
+    {{- partial "header.html" . -}}
+    <main role="main">
+      {{- block "main" . }}{{- end }}
+    </main>
+    {{- partial "footer.html" . -}}
+  </body>
 </html>

--- a/themes/salix/layouts/index.html
+++ b/themes/salix/layouts/index.html
@@ -1,3 +1,8 @@
+{{ define "contact" }}
+<a id="contactfloat" href="#contact">
+	<img src="/img/chat_icon.svg" alt="Contact Us"/>
+</a>
+{{ end }}
 {{ define "main" }}
 	{{ .Content }}
 {{ end }}

--- a/themes/salix/layouts/partials/header.html
+++ b/themes/salix/layouts/partials/header.html
@@ -1,6 +1,3 @@
-<a id="contactfloat" href="#contact">
-	<img src="/img/chat_icon.svg" alt="Contact Us"/>
-</a>
 <header {{ with .Page.IsHome }} class='homepage' {{ end }} >
 	<h1>{{ replace (.Site.Title | plainify) " " "<br/>" | safeHTML}}.</h1>
 	{{ if .Site.Params.description }}


### PR DESCRIPTION
This makes the contact button overrideable and doesn't show it on pages that aren't the home page.