### PR TITLE
Full width header

### DIFF
--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -93,14 +93,14 @@ section.columns-section h2 {
 	margin: 0 auto;
 }
 
-section.columns-section > div > div {
+section.columns-section > div {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	margin: 0 auto;
 }
 
-section.columns-section > div > div div {
+section.columns-section > div div {
 	border-bottom: 2px solid white;
 	width: 30%;
 	max-width: 25rem;

--- a/themes/salix/assets/css/main.css
+++ b/themes/salix/assets/css/main.css
@@ -48,12 +48,10 @@ header {
 	background-size: 1024px;
 	color: var(--color-blue);
 	display: flex;
-	height: 100%;
+	min-height: 100vh;
 	justify-content: space-between;
 	margin: 0 auto;
-	max-height: 100vh;
-	max-width: 1650px;
-	padding: 5rem;
+	padding: 5rem calc((100% - 1650px) / 2);
 	width: 100%;
 }
 
@@ -69,8 +67,8 @@ header h1 {
 }
 
 header p {
-	font-size: 2rem;
-	width: 20rem;
+	font-size: 3rem;
+	max-width: 33%;
 }
 
 section h2 {
@@ -153,26 +151,22 @@ section.minimal-section a {
 	font-weight: bold;
 }
 
-@media (max-width: 945px) {
+@media (orientation: portrait) {
 	header {
-		padding: 0;
+		flex-direction: column;
+	}
+
+	header p {
+		max-width: 100%;
+		padding: 1rem;
+	}
+
+	h1 {
+		font-size: calc(100vw / 5) !important;
 	}
 
 	section {
 		padding: 1rem;
-	}
-
-	header {
-		flex-direction: column;
-		font-size: 1rem;
-	}
-
-	header p {
-		font-size: 1.75rem;
-	}
-
-	h1 {
-		font-size: 5rem !important;
 	}
 }
 

--- a/themes/salix/layouts/shortcodes/flexsection.html
+++ b/themes/salix/layouts/shortcodes/flexsection.html
@@ -1,6 +1,6 @@
 <section{{ with .Get "class" }} class="{{.}}"{{ end }}>
 	<h2>{{ .Get "title" }}</h2>
-	<div><div>
+	<div>
 	{{ .Inner | safeHTML }}
-	</div></div>
+	</div>
 </section>


### PR DESCRIPTION
The header was overflowing on some small phone screens and the slogan was running off into the next section. This is my attempt to fix it and make the header work in both landscape and portrait orientation.